### PR TITLE
Fixing typo in readme for Bright Lights

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ preview image using the following steps.
 
 ![Screenshot](screenshots/borland.png)
 
-### Bright Ligths
+### Bright Lights
 
 ![Screenshot](screenshots/bright_lights.png)
 


### PR DESCRIPTION
The Bright Lights theme in the readme was spelled `Bright Ligths`. Corrected this to be spelled `Bright Lights`.